### PR TITLE
[hunspell] Fix string append

### DIFF
--- a/recipes/hunspell/all/conandata.yml
+++ b/recipes/hunspell/all/conandata.yml
@@ -5,3 +5,9 @@ sources:
   "1.7.0":
     sha256: "57be4e03ae9dd62c3471f667a0d81a14513e314d4d92081292b90435944ff951"
     url: https://github.com/hunspell/hunspell/files/2573619/hunspell-1.7.0.tar.gz
+patches:
+  "1.7.2":
+    - patch_file: "patches/0001-fix-basic-string.patch"
+      patch_description: "Fix build problem with basic_string::append()"
+      patch_type: "official"
+      patch_source: "https://github.com/hunspell/hunspell/commit/a6cb9f609b0292df12e2e855c97303de306bae44"

--- a/recipes/hunspell/all/conanfile.py
+++ b/recipes/hunspell/all/conanfile.py
@@ -1,23 +1,20 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get
-from conan.tools.scm import Version
+from conan.tools.files import copy, get, export_conandata_patches, apply_conandata_patches
 import os
+
 
 required_conan_version = ">=1.53.0"
 
+
 class HunspellConan(ConanFile):
     name = "hunspell"
-    description = (
-        "Hunspell is a free spell checker and morphological analyzer library"
-    )
+    description = "Hunspell is a free spell checker and morphological analyzer library"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://hunspell.github.io/"
     topics = "spell", "spell-check"
     license = "MPL-1.1", "GPL-2.0-or-later", "LGPL-2.1-or-later"
-
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -29,25 +26,8 @@ class HunspellConan(ConanFile):
         "fPIC": True,
     }
 
-    @property
-    def _minimum_cpp_standard(self):
-        return 11
-
-    @property
-    def _minimum_compilers_version(self):
-        return {
-            "gcc": "7",
-        }
-
-    def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._minimum_cpp_standard)
-        min_version = self._minimum_compilers_version.get(str(self.settings.compiler))
-        if min_version:
-            if Version(self.settings.compiler.version) < min_version:
-                raise ConanInvalidConfiguration(f"{self.name} requires at least {self.settings.compiler} {min_version}")
-
     def export_sources(self):
+        export_conandata_patches(self)
         # TODO: Remove once PR is merged: https://github.com/hunspell/hunspell/pull/704/
         copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
 
@@ -69,12 +49,17 @@ class HunspellConan(ConanFile):
         h = os.path.join(self.source_folder, "src", "hunspell", "hunvisapi.h")
         os.remove(h)
 
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 11)
+
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["CONAN_hunspell_VERSION"] = self.version
         tc.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()

--- a/recipes/hunspell/all/patches/0001-fix-basic-string.patch
+++ b/recipes/hunspell/all/patches/0001-fix-basic-string.patch
@@ -1,0 +1,71 @@
+diff --git a/src/hunspell/affentry.cxx b/src/hunspell/affentry.cxx
+index 46e8b5826..6ee23bec9 100644
+--- a/src/hunspell/affentry.cxx
++++ b/src/hunspell/affentry.cxx
+@@ -290,7 +290,7 @@ struct hentry* PfxEntry::check_twosfx(const std::string& word,
+     // back any characters that would have been stripped
+
+     std::string tmpword(strip);
+-    tmpword.append(word, start + appnd.size());
++    tmpword.append(word, start + appnd.size(), tmpl);
+
+     // now make sure all of the conditions on characters
+     // are met.  Please see the appendix at the end of
+@@ -338,7 +338,7 @@ std::string PfxEntry::check_twosfx_morph(const std::string& word,
+     // back any characters that would have been stripped
+
+     std::string tmpword(strip);
+-    tmpword.append(word, start + appnd.size());
++    tmpword.append(word, start + appnd.size(), tmpl);
+
+     // now make sure all of the conditions on characters
+     // are met.  Please see the appendix at the end of
+@@ -386,7 +386,7 @@ std::string PfxEntry::check_morph(const std::string& word,
+     // back any characters that would have been stripped
+
+     std::string tmpword(strip);
+-    tmpword.append(word, start + appnd.size());
++    tmpword.append(word, start + appnd.size(), tmpl);
+
+     // now make sure all of the conditions on characters
+     // are met.  Please see the appendix at the end of
+diff --git a/src/hunspell/affixmgr.cxx b/src/hunspell/affixmgr.cxx
+index 4d1ad2f12..a8931c14a 100644
+--- a/src/hunspell/affixmgr.cxx
++++ b/src/hunspell/affixmgr.cxx
+@@ -2465,7 +2465,7 @@ int AffixMgr::compound_check_morph(const std::string& word,
+           result.append(presult);
+           result.push_back(MSEP_FLD);
+           result.append(MORPH_PART);
+-          result.append(word, i);
++          result.append(word, i, word.size());
+           if (complexprefixes && HENTRY_DATA(rv))
+             result.append(HENTRY_DATA2(rv));
+           if (!HENTRY_FIND(rv, MORPH_STEM)) {
+@@ -2522,7 +2522,7 @@ int AffixMgr::compound_check_morph(const std::string& word,
+           result.append(presult);
+           result.push_back(MSEP_FLD);
+           result.append(MORPH_PART);
+-          result.append(word, i);
++          result.append(word, i, word.size());
+
+           if (HENTRY_DATA(rv)) {
+             if (complexprefixes)
+@@ -2573,7 +2573,7 @@ int AffixMgr::compound_check_morph(const std::string& word,
+             if (!m.empty()) {
+               result.push_back(MSEP_FLD);
+               result.append(MORPH_PART);
+-              result.append(word, i);
++              result.append(word, i, word.size());
+               line_uniq_app(m, MSEP_REC);
+               result.append(m);
+             }
+@@ -2665,7 +2665,7 @@ int AffixMgr::compound_check_morph(const std::string& word,
+           if (!m.empty()) {
+             result.push_back(MSEP_FLD);
+             result.append(MORPH_PART);
+-            result.append(word, i);
++            result.append(word, i, word.size());
+             line_uniq_app(m, MSEP_REC);
+             result.push_back(MSEP_FLD);
+             result.append(m);


### PR DESCRIPTION
Hunspell should be able to build with GCC 5 and it has been fixed already in the upstream.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
